### PR TITLE
Add aarch64 support

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -47,6 +47,7 @@ architecture() {
   i686) echo "386" ;;
   x86_64) echo "amd64" ;;
   arm64) echo "arm64" ;;
+  aarch64) echo "arm64" ;;
   esac
 }
 


### PR DESCRIPTION
Hi there!
The following stems from an issue where `uname -m` reports `aarch64` instead of `arm64`.

Provided I'm a total idiot, hopefully the following effectively explains context:

1. In a `Dockerfile` with `FROM golang:1.22-alpine` observe the output of `uname -m` is `aarch64`
2. Because the `architecture` case is missing said entry, the resulting release URL is invalid e.g. `https://github.com/go-swagger/go-swagger/releases/download/v0.30.5/swagger_linux_`
3. As far as I know the `arm64` release functions properly on alpine Linux, thus simply appending to the `architecture` cases remedies this issue.


